### PR TITLE
Fixed a bug which caused the program fail to terminate automatically

### DIFF
--- a/vivalib/channel.h
+++ b/vivalib/channel.h
@@ -142,7 +142,7 @@ namespace viva
         _consume.wait(guard, [&] {
             return (!isOpen() && _images.empty()) || !_images.empty();
         });
-        if (_images.empty() && !isOpen())
+        if (_images.empty() || !isOpen())
         {
             guard.unlock();
             return false;


### PR DESCRIPTION
Hello Andres,

"getData" function should return **false** when the program run out of input images **or** the input file is not open.
