### PR TITLE
Fixed tracking infinite loop with -o command-line argument

### DIFF
--- a/vivalib/channel.h
+++ b/vivalib/channel.h
@@ -142,7 +142,7 @@ namespace viva
         _consume.wait(guard, [&] {
             return (!isOpen() && _images.empty()) || !_images.empty();
         });
-        if (_images.empty() || !isOpen())
+        if (_images.empty() && !isOpen())
         {
             guard.unlock();
             return false;

--- a/vivalib/viva.cpp
+++ b/vivalib/viva.cpp
@@ -204,7 +204,7 @@ void Processor::run()
 
             try
             {
-                key = waitKey(1);
+                key = waitKey(1) & 0xFF;
             }
             catch (...)
             {
@@ -355,7 +355,7 @@ void BatchProcessor::run()
 
             try
             {
-                key = waitKey(1);
+                key = waitKey(1) & 0xFF;
             }
             catch (...)
             {


### PR DESCRIPTION
Using the VOT2015 dataset and the example command given  in the project wiki:
`./vivaTracker -m=skcf vot2015/ball2 -o=skcf.txt`
The tracker will run but cannot exit out of the while() loop in Processor::run() (vivalib/viva.cpp: line 155).

The while() loop exit condition is `running && ( _input_channel->isOpen() || !_input_channel->empty()))`. Ignoring the `running` variable, `_input_channel->isOpen)` must be `true` and  `input_channel->empty()` must be `false` to exit the loop. 

From vivalib/channel.h, it was discovered that `_input_channel` is an image buffer with a default buffer size of 10. It will be "terminated" (`_input_channel->isOpen()` returns false) when the input sequence has less than or equal to 10 images remaining. 

However, some debugging revealed that `_input_channel->empty()` continues to return true. This is because `_input_channel->getData(frame)` (vivalib/viva.cpp: line 163) returns `false` WHILE THERE ARE STILL IMAGES LEFT IN THE BUFFER. 

This lead to the 1 line change made in vivalib/channel.h, line 145. `BufferedChannel<Data>::getData()` returns false if the internal image buffer `_images.empty()` is true OR the buffer is "terminated". As mentioned above, the buffer is "terminated" if there are no images/frames to be read. However, the `Processor` still needs to process the final frames in the buffer, and hence empty the buffer, to exit the while() loop. 

I changed the `if()` condition mentioned above from `||` to `&&`  so that, even if the buffer is "terminated", the remaining images/frames in the buffer will still be `pop_front`'d to empty the buffer. The loop will now exit and the output file specified by the `-o` argument will be created.